### PR TITLE
Fix PIDFILE check to look for PIDFILE, not DATADIR

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,7 @@ IP_ADDRESS=$(ip a | grep eth0 | grep inet | awk {'print $2'} | cut -d '/' -f 1 |
 DATADIR=/var/lib/mysql
 PIDFILE=${DATADIR}/mysqld.pid
 
-if [ "$(ls -A $DATADIR)" ]; then
+if [ "$(ls -A $PIDFILE)" ]; then
 	echo ">> Datadir is not empty"
 	[ -f $PIDFILE ] && rm -f $PIDFILE
 else


### PR DESCRIPTION
My container kept crashing because I had a `lost+found` directory in the `DATADIR`. Changing the check to explicitly look for the `PIDFILE` (within the `DATADIR` per the script's config) fixed things.