### PR TITLE
Change how the rpc token is generated. Python is not needed

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -207,7 +207,7 @@ else
 
 	## Configure CMON service
 
-	CMON_TOKEN=$(python -c 'import uuid; print uuid.uuid4()' | sha1sum | cut -f1 -d' ')
+	CMON_TOKEN=$(cat /proc/sys/kernel/random/uuid | sha1sum | cut -f1 -d' ')
 	echo
 	echo ">> Setting up minimal $CMON_CONFIG.."
 	cat /dev/null > $CMON_CONFIG


### PR DESCRIPTION
Hey @ashraf-s9s, we don't need to use python to generate the rpc token. This is what we do in the install-cc script now.